### PR TITLE
0.1/medicine jiwon [증상 키워드 기반 의약품 추천 streamlit 기본 구현]

### DIFF
--- a/pages/2_medicine.py
+++ b/pages/2_medicine.py
@@ -20,18 +20,18 @@ def recommend_by_overlap(user_input, df, top_n=5):
     
     df['score'] = df['efcy_nouns'].apply(overlap_score)
     result = df[df['score'] > 0].sort_values(by='score', ascending=False).head(top_n)
-    return result[['itemName', 'entpName', 'efcyQesitm', 'score']]
+    return result[['itemName_clean', 'entpName', 'efcyQesitm', 'atpnQesitm', 'atpnWarnQesitm', 'seQesitm', 'score']]
 
 # 데이터 불러오기
 @st.cache_data
 def load_data():
-    df = pd.read_csv("~/temp/add-more/data/medicine_info_with_nouns.csv")
+    df = pd.read_csv("pages/medicine_info_with_nouns.csv")
     df = df.fillna("")
     return df
 
 # Streamlit 앱 구성
-st.title("💊 단어 겹침 기반 의약품 추천기")
-st.write("입력한 증상과 가장 관련된 약품을 추천합니다.")
+st.title("💊 의약품 추천")
+st.write("입력한 증상과 가장 관련된 의약품을 추천합니다.")
 
 user_input = st.text_input("📝 증상 또는 질환 입력", placeholder="예: 소화불량, 기침, 위염")
 
@@ -40,12 +40,20 @@ if user_input:
     result = recommend_by_overlap(user_input, df)
 
     if not result.empty:
-        st.subheader("📋 추천 결과")
-        for _, row in result.iterrows():
-            st.markdown(f"### {row['itemName']} ({row['entpName']})")
-            st.write(f"**효능:** {row['efcyQesitm']}")
-            st.write(f"**공통 키워드 개수:** {row['score']}")
-            st.markdown("---")
-    else:
-        st.warning("관련된 의약품을 찾을 수 없습니다.")
+        st.subheader("📋 추천 의약품 목록")
 
+        for i, row in result.iterrows():
+            with st.container():
+                st.markdown(f"### {row['itemName_clean']} ({row['entpName']})")
+                st.markdown(f"**✔️ 주요 효능:** {row['efcyQesitm'][:100]}{'...' if len(row['efcyQesitm']) > 100 else ''}")
+                st.markdown(f"**🔗 공통 키워드 개수:** `{row['score']}`")
+                
+                with st.expander("🔍 상세 보기"):
+                    st.markdown(f"**📌 전체 효능 설명**\n\n{row['efcyQesitm']}")
+                    st.markdown(f"**⚠️ 주의사항**\n\n{row.get('atpnQesitm', '정보 없음')}")
+                    st.markdown(f"**⚠️ 주의사항 경고**\n\n{row.get('atpnWarnQesitm', '정보 없음')}")
+                    st.markdown(f"**🚫 부작용**\n\n{row.get('seQesitm', '정보 없음')}")
+                
+                st.markdown("---")
+    else:
+        st.warning("😥 관련된 의약품을 찾을 수 없습니다. 다른 증상을 입력해보세요.")


### PR DESCRIPTION
📌 작업 내용

- 아직 질병 데이터와 연결 하지 못하여서 일단 1차로 증상을 직접 입력하면 의약품 데이터의 효능 키워드와 비교해 공통 키워드 개수가 많은 것 5가지를 추천해주는 코드를 작성했습니다.
(상세 보기 버튼을 만들어서 주의사항이나 부작용 같은 길이가 긴 항목을 따로 표시하도록 했음)

🛠 변경 파일

- pages/2_medicine.py

✅ 확인 사항

- [ ] 1차 streamlit 구현을 위한 기본 틀 식으로 코드 작성 -> 추후 csv파일을 불러오는 경로를 변경해야 함 
- [ ] 일단 공유 cloud의 의약품 형태소 분석 파일 csv를 다운 받아서 pages 폴더에 넣어 놔야 test 가능