### PR TITLE
0.1/medicine jiwon [의약품 추천 함수에 가중치 계산 로직 추가]

### DIFF
--- a/main.py
+++ b/main.py
@@ -95,7 +95,7 @@ with col3:
         """
         <a href='/medicine' target='_self' style='text-decoration: none;'>
             <div class='card'>
-                <h3>💊 약 추천</h3>
+                <h3>💊 의약품 추천</h3>
                 <p>질병/증상에 맞는 의약품 정보를 제공합니다.</p>
             </div>
         </a>

--- a/pages/3_medicine.py
+++ b/pages/3_medicine.py
@@ -23,6 +23,7 @@ def extract_nouns(text):
 def recommend_with_weights(user_input, df, top_n=5):
     user_nouns = set(extract_nouns(user_input))
     user_noun_count = len(user_nouns)
+    # 약물 복용 시 부작용 가능성이 높은 고위험군이나 장기 기능 저하 상태를 나타내는 키워드로, 해당 내용이 없을수록 대부분의 사람이 안전하게 복용할 수 있음
     RISK_KEYWORDS = ['과민증', '어린이', '고령자', '간장애', '신장애', '임산부', '수유부', '간질환', '신부전']
 
     if user_noun_count == 0:

--- a/pages/3_medicine.py
+++ b/pages/3_medicine.py
@@ -3,6 +3,8 @@ import streamlit as st
 import pandas as pd
 from konlpy.tag import Okt
 
+st.set_page_config(page_title="의약품 추천", layout="wide")
+
 # 형태소 분석기
 okt = Okt()
 


### PR DESCRIPTION
📌 작업 내용

- 단순 겹치는 형태소 단어 count로 추천했던 함수를 가중치를 주어서 관련도를 계산해 추천하도록 코드를 수정했습니다.
- 1차 가중치 점수 표 (10점 만점)
```bash
증상 관련도(입력한 증상이 의약품의 효능과 다 겹치면 만점) - 6점
주의 사항 경고 없음 - 1점
위험 키워드 적음(주의 사항이 비어있거나, '과민증', '어린이', '고령자' 등 키워드가 없으면 만점)- 2점
부작용 설명 짧음(없거나 짧을수록 가산점) - 1점
```
- main 페이지에서 페이지 설명 카드 내용 중 약추천 -> 의약품 추천 으로 변경했습니다.

🛠 변경 파일

pages/3_medicine.py
main.py

✅ 확인 사항

- [ ] 추천 로직에서 가중치 계산 추가 -> 가중치 기준에 대해서 추가 사항이나 잘 못된 점이 있다면 의견 남겨주세요!

☑️ 추후 수정 사항

- [ ] 추후 형태소 분석과 가중치 모두 고도화 예정 
- [ ] 질병 데이터와 연결해서 추천 알고리즘 계산 필요