### PR TITLE
v0.9/dev [통합 챗봇 프로토타입 완성]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -180,3 +180,5 @@ Dockerfile
 LLM_code/hospital/faiss_index/index.faiss
 LLM_code/hospital/hospi_faiss_index_parallel/index.faiss
 app/api/hospi_faiss_index/index.faiss
+app/api/faiss_store/index.faiss
+app/api/faiss_store/index.pkl

--- a/LLM_code/amedi_embedding.py
+++ b/LLM_code/amedi_embedding.py
@@ -1,0 +1,34 @@
+from langchain_community.embeddings import HuggingFaceEmbeddings
+from langchain.schema import Document
+from langchain.vectorstores import FAISS
+from langchain.text_splitter import RecursiveCharacterTextSplitter
+import pandas as pd
+import os
+
+def load_csv_as_documents(file_path, file_label, chunk_size=500, chunk_overlap=50):
+    df = pd.read_csv(file_path)
+    docs = []
+    for idx, row in df.iterrows():
+        content = "\n".join([f"{col}: {row[col]}" for col in df.columns])
+        doc = Document(
+            page_content=content,
+            metadata={"source_file": file_label, "row_index": str(idx)}
+        )
+        docs.append(doc)
+
+    text_splitter = RecursiveCharacterTextSplitter(chunk_size=chunk_size, chunk_overlap=chunk_overlap)
+    return text_splitter.split_documents(docs)
+
+# 데이터 로드 및 문서화
+dis_docs = load_csv_as_documents("docs/dis_prototype.csv", "질병")
+med_docs = load_csv_as_documents("docs/testmed.csv", "의약품")
+all_docs = dis_docs + med_docs
+
+# 임베딩 및 벡터스토어 생성
+embedding_model_name = "madatnlp/km-bert"
+embeddings = HuggingFaceEmbeddings(model_name=embedding_model_name)
+vectorstore = FAISS.from_documents(all_docs, embeddings)
+
+# 디렉터리 생성
+os.makedirs("faiss_store", exist_ok=True)
+vectorstore.save_local("faiss_store")

--- a/LLM_code/amedi_embedding.py
+++ b/LLM_code/amedi_embedding.py
@@ -16,19 +16,28 @@ def load_csv_as_documents(file_path, file_label, chunk_size=500, chunk_overlap=5
         )
         docs.append(doc)
 
-    text_splitter = RecursiveCharacterTextSplitter(chunk_size=chunk_size, chunk_overlap=chunk_overlap)
+    text_splitter = RecursiveCharacterTextSplitter(
+        chunk_size=chunk_size,
+        chunk_overlap=chunk_overlap
+    )
     return text_splitter.split_documents(docs)
 
-# 데이터 로드 및 문서화
-dis_docs = load_csv_as_documents("docs/dis_prototype.csv", "질병")
-med_docs = load_csv_as_documents("docs/testmed.csv", "의약품")
-all_docs = dis_docs + med_docs
+def build_vectorstore():
+    # 데이터 로드 및 문서화
+    dis_docs = load_csv_as_documents("LLM_code/dis_prototype.csv", "질병")
+    med_docs = load_csv_as_documents("LLM_code/testmed.csv", "의약품")
+    all_docs = dis_docs + med_docs
 
-# 임베딩 및 벡터스토어 생성
-embedding_model_name = "madatnlp/km-bert"
-embeddings = HuggingFaceEmbeddings(model_name=embedding_model_name)
-vectorstore = FAISS.from_documents(all_docs, embeddings)
+    # 임베딩 및 벡터스토어 생성
+    embedding_model_name = "madatnlp/km-bert"
+    embeddings = HuggingFaceEmbeddings(model_name=embedding_model_name)
+    vectorstore = FAISS.from_documents(all_docs, embeddings)
 
-# 디렉터리 생성
-os.makedirs("faiss_store", exist_ok=True)
-vectorstore.save_local("faiss_store")
+    # 저장 경로: app/api/faiss_store
+    save_path = "app/api/faiss_store"
+    os.makedirs(save_path, exist_ok=True)
+    vectorstore.save_local(save_path)
+    print(f"✅ FAISS 벡터스토어가 '{save_path}' 경로에 저장되었습니다.")
+
+if __name__ == "__main__":
+    build_vectorstore()

--- a/README.md
+++ b/README.md
@@ -1,24 +1,21 @@
-# 🧠 AmedI: 당신의 증상에 딱 맞는 AI 의료 도우미
+# AmedI: 당신의 증상에 딱 맞는 AI 의료 도우미
 
 **AmedI**는 사용자 증상을 자연어로 입력하면, AI가 질병을 예측하고 관련 의약품과 위치 기반 병원을 추천해주는 **지능형 헬스케어 서비스**입니다.
 
 > 본 프로젝트는 **LG Whynot SW 캠프 4기** ‘더해보다’ 팀이 개발하였습니다.
 > 
 ---
-## 👥 팀 소개
+##  팀 소개 
 
-| 이름     | 역할 |
-|----------|------|
-| **안재영** | 프로젝트 리더 – 백엔드 (증상·질병) 전체 기획/운영 |
-| **강현룡** | 애자일 코치 – 프론트·백엔드 (병원) UI + 협업 관리 |
-| **조민규** | 테크 리더 – 프론트 및 AWS·DB 엔지니어 |
-| **백지원** | 형상 관리자 – 백엔드 (의약품) Git/GitHub 및 워크플로우 최적화 |
-
-
+| **안재영** | **강현룡** | **조민규** | **백지원** |
+|-----------|-----------|-----------|-----------|
+| ![Project&nbsp;Leader](https://img.shields.io/badge/Project%20Leader-2962FF?style=plastic&logoColor=white) | ![Agile&nbsp;Coach](https://img.shields.io/badge/Agile%20Coach-43A047?style=plastic&logoColor=white) | ![Tech&nbsp;Lead](https://img.shields.io/badge/Tech%20Lead-FFB300?style=plastic&logoColor=white) | ![Config&nbsp;Mgr](https://img.shields.io/badge/Config%20Mgr-F57C00?style=plastic&logoColor=white) |
+|![AI](https://img.shields.io/badge/AI-7E57C2?style=plastic&logo=openai&logoColor=white) ![BackEnd](https://img.shields.io/badge/BackEnd-3776AB?style=plastic&logo=python&logoColor=white)<br> 증상·질병<br>운영 및 총괄 | ![FrontEnd](https://img.shields.io/badge/FrontEnd-06B6D4?style=plastic&logo=react&logoColor=white) ![BackEnd](https://img.shields.io/badge/BackEnd-3776AB?style=plastic&logo=python&logoColor=white)<br> 병원<br> UI·협업 및 LLM 보조  | ![FrontEnd](https://img.shields.io/badge/FrontEnd-06B6D4?style=plastic&logo=react&logoColor=white)  ![Cloud](https://img.shields.io/badge/Cloud-FF9900?style=plastic&logo=amazonaws&logoColor=white) <br> AWS·DB 엔지니어| ![AI](https://img.shields.io/badge/AI-7E57C2?style=plastic&logo=openai&logoColor=white) ![BackEnd](https://img.shields.io/badge/BackEnd-3776AB?style=plastic&logo=python&logoColor=white)<br> 의약품 <br> GitOps 기획·최적화 |
+| [![GitHub](https://img.shields.io/badge/GitHub-181717?style=plastic&logo=github&logoColor=white)](https://github.com/Jacob-53) | [![GitHub](https://img.shields.io/badge/GitHub-181717?style=plastic&logo=github&logoColor=white)](https://github.com/stundrg) | [![GitHub](https://img.shields.io/badge/GitHub-181717?style=plastic&logo=github&logoColor=white)](https://github.com/cho6019) | [![GitHub](https://img.shields.io/badge/GitHub-181717?style=plastic&logo=github&logoColor=white)](https://github.com/jiwon1118) |
 
 ---
 
-## 📌 개요
+##  개요
 
 - 자연어 기반 **증상 입력**
 - LLM 기반 **질병 예측**
@@ -28,52 +25,52 @@
 
 ---
 
-## 🏁 프로젝트 목표
+##  프로젝트 목표
 
-- ✅ 정확한 증상-질병 매칭 시스템 개발
-- ✅ 실시간 FastAPI 서버 및 Chatbot 구축
-- ✅ 위치 기반 병원 추천 알고리즘 개발
-- ✅ Docker + AWS EC2 기반 배포 환경 구축
+-  정확한 증상-질병 매칭 시스템 개발
+-  실시간 FastAPI 서버 및 Chatbot 구축
+-  위치 기반 병원 추천 알고리즘 개발
+-  Docker + AWS EC2 기반 배포 환경 구축
 
 ---
 
-## 🚀 핵심 기능 요약
+##  핵심 기능 요약
 
 | 기능                  | 설명 |
 |-----------------------|------|
 | 질병 예측             | RAG + EXAONE 기반 질병 추론 및 추가 질문 |
 | 의약품 추천           | 입력 텍스트 또는 약물명 기반 메타데이터 유사도 매칭 |
-| 병원 추천             | 위치 + 진료과 기반 거리 필터 + LLM 사유 생성 |
+| 병원 추천             | 위치 + 진료과 기반 거리 필터  |
 | Chatbot UI            | 질의응답 기반 챗형 인터페이스 구성 |
 | 대시보드 통합         | 전체 예측 결과 및 상태 시각화 지원 |
 
 ---
 
-## 🧬 사용 기술 스택
+##  사용 기술 스택
 
-| 범주         | 기술 |
-|--------------|------|
-| 백엔드       | `Python`, `FastAPI`, `Pandas`, `SQLAlchemy` |
-| 프론트엔드   | `Next.js`, `React`, `Tailwind CSS` |
-| LLM          | `EXAONE 3.5:7.8B`,  `Langchain` |
-| 벡터 검색    | `FAISS`, `HuggingFaceEmbeddings`, `madatnlp/km-bert` |
-| 배포         | `Docker`, `AWS EC2`, `.env` 설정 |
-| 지도 API     | `Naver Map` |
-| 자동화/모니터링 | `Grafana` |
+| 범주 | 기술 |
+|----------|-------|
+| **Backend & API** | ![Python](https://img.shields.io/badge/Python-3776AB?style=plastic&logo=python&logoColor=white) ![FastAPI](https://img.shields.io/badge/FastAPI-009688?style=plastic&logo=fastapi&logoColor=white) ![Pandas](https://img.shields.io/badge/Pandas-150458?style=plastic&logo=pandas&logoColor=white) ![SQLAlchemy](https://img.shields.io/badge/SQLAlchemy-B7312F?style=plastic&logo=sqlalchemy&logoColor=white) |
+| **Frontend UI** | ![Next.js](https://img.shields.io/badge/Next.js-000000?style=plastic&logo=next.js&logoColor=white) ![React](https://img.shields.io/badge/React-61DAFB?style=plastic&logo=react&logoColor=000000) ![Tailwind CSS](https://img.shields.io/badge/Tailwind%20CSS-06B6D4?style=plastic&logo=tailwindcss&logoColor=white) |
+| **AI & LLM** | ![EXAONE 3.5](https://img.shields.io/badge/EXAONE%203.5:7.8B-00A6E1?style=plastic) ![LangChain](https://img.shields.io/badge/LangChain-000000?style=plastic&logo=langchain&logoColor=white) ![HF Embeddings](https://img.shields.io/badge/HuggingFace%20Embeddings-FCC624?style=plastic&logo=huggingface&logoColor=000000) ![km-bert](https://img.shields.io/badge/km--bert-006400?style=plastic) |
+| **Vector Store** | ![FAISS](https://img.shields.io/badge/FAISS-2284CC?style=plastic) |
+| **Database** | ![PostgreSQL](https://img.shields.io/badge/PostgreSQL-4169E1?style=plastic&logo=postgresql&logoColor=white) |
+| **DevOps & Infra** | ![Docker](https://img.shields.io/badge/Docker-2496ED?style=plastic&logo=docker&logoColor=white) ![AWS EC2](https://img.shields.io/badge/AWS%20EC2-FF9900?style=plastic&logo=amazonaws&logoColor=white) |
+| **Maps API** | ![Naver Map](https://img.shields.io/badge/Naver%20Map-03C75A?style=plastic&logo=naver&logoColor=white) |
+| **Monitoring** | ![Grafana](https://img.shields.io/badge/Grafana-F46800?style=plastic&logo=grafana&logoColor=white) |
+
 
 ---
 
-## 🧪 주요 LLM API 명세
+##  주요 LLM API 명세
 
 | 엔드포인트 | 설명 |
 |------------|------|
-| `POST /llm/hospital` | 질병 기반 병원 추천 (LLM) |
-| `POST /llm/medicine` | 의약품 설명 및 추천 |
-| `POST /llm/disease` | 증상 기반 질병 예측 |
+| `POST /llm/Amedi` | 자연어 증상 기반 질병 예측 및 의약품 추천 |
 
 ---
 
-## 🔗 데이터 출처
+##  데이터 출처
 
 - **질병 데이터**: 서울대병원, 서울아산병원 (크롤링)
 - **의약품 데이터**: e약은요 API
@@ -81,16 +78,16 @@
 
 ---
 
-## 🎯 기대 효과
+##  기대 효과
 
-- 🧑‍⚕️ **맞춤형 의료 의사결정 지원**
-- 🕒 **시간 절약형 병원·약 정보 제공**
-- 📊 **데이터 기반 건강 인사이트 생성**
-- 🌍 **현실 적용 가능한 실전형 서비스**
+-  **맞춤형 의료 의사결정 지원**
+-  **시간 절약형 병원·약 정보 제공**
+-  **데이터 기반 건강 인사이트 생성**
+-  **현실 적용 가능한 실전형 서비스**
 
 ---
 
-## 📸 시연 이미지 예시
+##  시연 이미지 예시
 
 - 병원 추천 지도 UI
 - LLM 응답 챗봇 화면
@@ -98,12 +95,12 @@
 
 ---
 
-## 🧪 향후 계획 (Suggestions)
+##  향후 계획 (Suggestions)
 
-- 📱 모바일 전용 UI 개발
-- 🔁 사용자 피드백 기반 질의 응답 개선
-- 🏥 응급실 실시간 혼잡도 연동 (공공데이터 API)
-- 🔬 LLM 비교 (Exaone vs Clova vs GPT 등)
+-  모바일 전용 UI 개발
+-  사용자 피드백 기반 질의 응답 개선
+-  응급실 실시간 혼잡도 연동 (공공데이터 API)
+-  LLM 비교 (Exaone vs Hyper Clova X vs GPT-4 등)
 
 ---
 
@@ -112,14 +109,13 @@
 ```bash
 # 백엔드
 cd backend
-python -m venv .venv && source .venv/bin/activate
-pip install -r requirements.txt
-uvicorn main:app --reload
+pdm install
+uvicorn app.main:app --reload
 
 # 프론트엔드
 cd frontend
-npm install
-npm run dev
+pnpm install
+pnpm dev
 ```
 
 환경변수 `.env` 예시:

--- a/app/api/amedi_llm_api.py
+++ b/app/api/amedi_llm_api.py
@@ -16,7 +16,7 @@ class QueryRequest(BaseModel):
 # 임베딩 모델 및 벡터스토어 로딩 (앱 실행 시 1회)
 embedding_model_name = "madatnlp/km-bert"
 embeddings = HuggingFaceEmbeddings(model_name=embedding_model_name)
-vectorstore = FAISS.load_local("faiss_store", embeddings, allow_dangerous_deserialization=True)
+vectorstore = FAISS.load_local("./app/api/faiss_store", embeddings, allow_dangerous_deserialization=True)
 
 # RAG 함수
 def rag_answer(question: str) -> str:

--- a/app/api/amedi_llm_api.py
+++ b/app/api/amedi_llm_api.py
@@ -21,7 +21,7 @@ vectorstore = FAISS.load_local("./app/api/faiss_store", embeddings, allow_danger
 # RAG 함수
 def rag_answer(question: str) -> str:
     retriever = vectorstore.as_retriever()
-    llm = Ollama(model="exaone3.5:7.8b", temperature=0.1, num_predict=1024)
+    llm = Ollama(model="exaone3.5:7.8b", temperature=0.3, num_predict=1024)
 
     system_template = (
         "너는 전문 의료 정보 비서야.\n"

--- a/app/api/amedi_llm_api.py
+++ b/app/api/amedi_llm_api.py
@@ -1,0 +1,58 @@
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+from langchain_community.llms import Ollama
+from langchain_community.embeddings import HuggingFaceEmbeddings
+from langchain.vectorstores import FAISS
+from langchain.prompts import ChatPromptTemplate, SystemMessagePromptTemplate, HumanMessagePromptTemplate
+from langchain.chains import RetrievalQA
+
+# FastAPI 라우터
+router = APIRouter()
+
+# 사용자 입력 스키마
+class QueryRequest(BaseModel):
+    question: str
+
+# 임베딩 모델 및 벡터스토어 로딩 (앱 실행 시 1회)
+embedding_model_name = "madatnlp/km-bert"
+embeddings = HuggingFaceEmbeddings(model_name=embedding_model_name)
+vectorstore = FAISS.load_local("faiss_store", embeddings, allow_dangerous_deserialization=True)
+
+# RAG 함수
+def rag_answer(question: str) -> str:
+    retriever = vectorstore.as_retriever()
+    llm = Ollama(model="exaone3.5:7.8b", temperature=0.1, num_predict=1024)
+
+    system_template = (
+        "너는 전문 의료 정보 비서야.\n"
+        "사용자의 질문을 보고, 질병 / 의약품 중 어떤 카테고리에 해당하는지 판단하고,\n"
+        "관련 있는 문서만 참고해서 답변해. 문서의 출처(source_file)를 확인해서 불필요한 문서는 무시해야 해.\n"
+        "정보가 명확하지 않거나 문서에 없다면 '모르겠습니다'라고 답변해."
+    )
+    human_template = (
+        "질문: {question}\n\n"
+        "참고 가능한 문서 리스트 (내용과 출처 포함):\n\n{context}"
+    )
+    chat_prompt = ChatPromptTemplate.from_messages([
+        SystemMessagePromptTemplate.from_template(system_template),
+        HumanMessagePromptTemplate.from_template(human_template)
+    ])
+
+    qa = RetrievalQA.from_chain_type(
+        llm=llm,
+        retriever=retriever,
+        return_source_documents=True,
+        chain_type_kwargs={"prompt": chat_prompt}
+    )
+
+    result = qa.invoke({"query": question})
+    return result["result"]
+
+# POST /rag 엔드포인트
+@router.post("/llm/amedi")
+async def get_rag_response(query: QueryRequest):
+    try:
+        answer = rag_answer(query.question)
+        return {"question": query.question, "answer": answer}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))

--- a/app/api/hospital_api.py
+++ b/app/api/hospital_api.py
@@ -1,66 +1,88 @@
 from fastapi import APIRouter, Query, HTTPException
-from fastapi.middleware.cors import CORSMiddleware
-from typing import Dict, Any
+from typing   import Dict, Any, List, Optional
 from pydantic import BaseModel
-from typing import List, Optional
 from sqlalchemy import create_engine
 import pandas as pd
 import numpy as np
-import os
-import requests
+import os, requests
 from dotenv import load_dotenv
 
 load_dotenv()
 router = APIRouter()
 
-DATABASE_URL = os.getenv("DATABASE_URL")
+DATABASE_URL     = os.getenv("DATABASE_URL")
 NAVER_MAP_ID     = os.getenv("NEXT_PUBLIC_MAP_CLIENT_ID")
 NAVER_MAP_SECRET = os.getenv("NEXT_PUBLIC_MAP_CLIENT_SECRET")
+
 engine = create_engine(DATABASE_URL)
 
+
+# ────────────────────────────── 공통 함수 ──────────────────────────────
 def haversine(lat1, lon1, lat2s, lon2s):
-    R = 6371
-    dlat = np.radians(lat2s - lat1)
-    dlon = np.radians(lon2s - lon1)
-    a = np.sin(dlat/2)**2 + np.cos(np.radians(lat1)) * np.cos(np.radians(lat2s)) * np.sin(dlon/2)**2
+    """벡터라이즈된 하버사인 거리(km)"""
+    R     = 6371
+    dlat  = np.radians(lat2s - lat1)
+    dlon  = np.radians(lon2s - lon1)
+    a     = np.sin(dlat / 2) ** 2 + np.cos(np.radians(lat1)) * np.cos(np.radians(lat2s)) * np.sin(dlon / 2) ** 2
     return R * 2 * np.arctan2(np.sqrt(a), np.sqrt(1 - a))
 
-class FilterRequest(BaseModel):
-    lat: float
-    lon: float
-    radius: float = 1.0
-    deps: Optional[List[str]] = None
-    search_name: Optional[str] = None
 
+# ────────────────────────────── 스키마 ──────────────────────────────
+class FilterRequest(BaseModel):
+    lat:  float
+    lon:  float
+    radius: float = 1.0
+    deps:  Optional[List[str]] = None
+    search_name: Optional[str] = None
+    only_er: bool = False          # 🆘 응급실만 보기 체크박스용
+
+
+# ────────────────────────────── 라우터 ──────────────────────────────
 @router.post("/api/hospital")
 def filter_hospitals(req: FilterRequest):
+    # ① 필요한 컬럼 모두 SELECT
     query = """
-    SELECT hos_nm, hos_type, pv, city, add, deps, lat, lon
-    FROM testhosp
-"""
+        SELECT hos_nm, hos_type, pv, city, add, deps,
+               emer, emer_phone,            -- 응급실 정보
+               lat, lon
+        FROM testhosp
+    """
     df = pd.read_sql(query, engine).dropna(subset=["lat", "lon"])
+
+    # ② 거리 계산
     df["distance"] = haversine(req.lat, req.lon, df["lat"].values, df["lon"].values)
 
-    # 진료과 필터
+    # ③ 진료과 필터
     if req.deps and req.deps != ["string"]:
-        df = df[df["deps"].apply(lambda t: any(dept.strip() in t.split(",") for dept in req.deps if t))]
+        df = df[df["deps"].apply(lambda t: any(d.strip() in t.split(",") for d in req.deps if t))]
 
-    # 병원명 필터
+    # ④ 병원명 검색
     if req.search_name and req.search_name != "string":
         df = df[df["hos_nm"].str.contains(req.search_name, case=False, na=False)]
 
+    # ⑤ 응급실만 보기
+    if req.only_er:
+        df = df[df["emer"].str.strip() == "있음"]
+
+    # ⑥ 반경·정렬
     df = df[df["distance"] <= req.radius].sort_values("distance")
+
+    # ⑦ 결과 직렬화
     records = []
-    for _, row in df.head(30).iterrows():
+    for _, row in df.head(30).iterrows():   # 최대 30개
         records.append({
-            "hos_nm": row["hos_nm"],
-            "add": row["add"],
-            "deps": row["deps"],
-            "lat": row["lat"],
-            "lon": row["lon"],
-            "distance": round(row["distance"], 2)
+            "hos_nm":      row["hos_nm"],
+            "add":         row["add"],
+            "deps":        row["deps"],
+            "emer":        row["emer"],
+            "emer_phone":  row["emer_phone"],
+            "lat":         row["lat"],
+            "lon":         row["lon"],
+            "distance":    round(row["distance"], 2)
         })
+
     return {"recommendations": records}
+
 
 @router.get("/list_departments")
 def list_departments():
@@ -73,24 +95,26 @@ def list_departments():
 
     return sorted(all_depts)
 
+
 @router.get("/geocode")
 def geocode_address(query: str = Query(...)) -> Dict[str, Any]:
-    base = "https://maps.apigw.ntruss.com/map-geocode/v2/geocode"
+    base    = "https://maps.apigw.ntruss.com/map-geocode/v2/geocode"
     headers = {
         "X-NCP-APIGW-API-KEY-ID": NAVER_MAP_ID,
         "X-NCP-APIGW-API-KEY":    NAVER_MAP_SECRET
     }
     r = requests.get(base, headers=headers, params={"query": query}, timeout=10)
+
     if r.status_code != 200:
         raise HTTPException(status_code=502, detail=r.text)
-    arr = r.json().get("addresses", [])
-    if not arr:
+
+    addresses = r.json().get("addresses", [])
+    if not addresses:
         raise HTTPException(status_code=404, detail="주소를 찾을 수 없습니다.")
-    a = arr[0]
+
+    a = addresses[0]
     return {
         "lat": float(a["y"]),
         "lon": float(a["x"]),
         "address_name": a.get("roadAddress") or a.get("jibunAddress")
     }
-
-

--- a/app/main.py
+++ b/app/main.py
@@ -40,6 +40,10 @@ except ImportError as e:
     print(f"⚠️ LLM 질병 API 모듈을 찾을 수 없습니다: {e}")
     LLM_DISEASE_AVAILABLE = False
 
+# ========== 질병 + 의약품 통합 LLM API 라우터 import ==========
+from app.api import amedi_llm_api # 통합 LLM API (llm/amedi)
+
+
 # 환경변수 로드
 load_dotenv()
 
@@ -116,6 +120,12 @@ app.include_router(
     prefix="",  # /llm/hospital 그대로 사용
 )
 
+app.include_router(
+    amedi_llm_api.router, 
+    tags=["통합 LLM"],
+    prefix="",  
+)
+
 if LLM_DISEASE_AVAILABLE:
     app.include_router(
         disease_llm_router,
@@ -138,6 +148,7 @@ async def root():
         "의약품 추천 LLM": "/llm/medicine",
         "병원 추천": "/api/hospital",
         "병원 추천 LLM": "/llm/hospital",
+        "통합 예측 및 추천 LLM": "/llm/amedi",
         "API 문서": "/docs",
         "ReDoc 문서": "/redoc"
     }
@@ -161,6 +172,7 @@ async def root():
             "의약품 추천 llm": "/llm/medicine",
             "병원 추천": "/api/hospital",
             "병원 추천 llm": "/llm/hospital",
+            "통합 예측 및 추천 LLM": "/llm/amedi",
             "API 문서": "/docs",
             "ReDoc 문서": "/redoc"
         }

--- a/app/main.py
+++ b/app/main.py
@@ -66,10 +66,11 @@ app.add_middleware(
     allow_origins=[
         "http://localhost:3000",    # Next.js 개발 서버
         "http://127.0.0.1:3000",
-        "http://localhost:3001",    # 예비 포트
+        "http://localhost:3001",
+        "https://dev.addmore.kr",# 예비 포트
     ],
     allow_credentials=True,
-    allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+    allow_methods=["*"],
     allow_headers=["*"],
 )
 

--- a/backup_tool/restore_server.sh
+++ b/backup_tool/restore_server.sh
@@ -27,7 +27,7 @@ if [ "$MODE" == "-d" ]; then
   createdb -h $RDS_HOST -U $RDS_USER $RDS_DB
 fi
 
-pg_restore -h $RDS_HOST -U $RDS_USER -d $RDS_DB $DUMP_FILE
+pg_restore --no-owner -h $RDS_HOST -U $RDS_USER -d $RDS_DB $DUMP_FILE
 
 # 정리
 rm $DUMP_FILE

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "backend"
-version = "0.5.0"
+version = "0.9.0"
 description = "Default template for PDM package"
 authors = [
     {name = "jiwon1118", email = "b23386585@gmail.com"},


### PR DESCRIPTION
🛠 변경 파일

- https://github.com/add-mores/backend/pull/41

📌 작업 내용

- 질병과 의약품 안내를 하나의 챗봇으로 작성하여 사용 가능하도록 fastapi를 작성하였습니다.
- 관련 csv를 LLM의 RAG로 사용하기 위하여 "madatnlp/km-bert" 모델로 embedding 하였습니다.
- LLM 모델은 ollama에서 "exaone3.5:7.8b" 을 사용하였습니다.

✅ 확인 사항

 - faiss_store 폴더를 공유 드라이브에서 다운로드 후 app/api 폴더 안에다가 위치시켜주셔야 합니다.

☑️ 추후 수정 사항

- 병원 안내까지 추가된 통합 챗봇으로 고도화 할 예정입니다.