### PR TITLE
0.9/feat llm [질병 + 의약품 통합 LLM 활용 fastAPI 코드 작성]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -180,3 +180,5 @@ Dockerfile
 LLM_code/hospital/faiss_index/index.faiss
 LLM_code/hospital/hospi_faiss_index_parallel/index.faiss
 app/api/hospi_faiss_index/index.faiss
+app/api/faiss_store/index.faiss
+app/api/faiss_store/index.pkl

--- a/LLM_code/amedi_embedding.py
+++ b/LLM_code/amedi_embedding.py
@@ -1,0 +1,34 @@
+from langchain_community.embeddings import HuggingFaceEmbeddings
+from langchain.schema import Document
+from langchain.vectorstores import FAISS
+from langchain.text_splitter import RecursiveCharacterTextSplitter
+import pandas as pd
+import os
+
+def load_csv_as_documents(file_path, file_label, chunk_size=500, chunk_overlap=50):
+    df = pd.read_csv(file_path)
+    docs = []
+    for idx, row in df.iterrows():
+        content = "\n".join([f"{col}: {row[col]}" for col in df.columns])
+        doc = Document(
+            page_content=content,
+            metadata={"source_file": file_label, "row_index": str(idx)}
+        )
+        docs.append(doc)
+
+    text_splitter = RecursiveCharacterTextSplitter(chunk_size=chunk_size, chunk_overlap=chunk_overlap)
+    return text_splitter.split_documents(docs)
+
+# 데이터 로드 및 문서화
+dis_docs = load_csv_as_documents("docs/dis_prototype.csv", "질병")
+med_docs = load_csv_as_documents("docs/testmed.csv", "의약품")
+all_docs = dis_docs + med_docs
+
+# 임베딩 및 벡터스토어 생성
+embedding_model_name = "madatnlp/km-bert"
+embeddings = HuggingFaceEmbeddings(model_name=embedding_model_name)
+vectorstore = FAISS.from_documents(all_docs, embeddings)
+
+# 디렉터리 생성
+os.makedirs("faiss_store", exist_ok=True)
+vectorstore.save_local("faiss_store")

--- a/LLM_code/amedi_embedding.py
+++ b/LLM_code/amedi_embedding.py
@@ -16,19 +16,28 @@ def load_csv_as_documents(file_path, file_label, chunk_size=500, chunk_overlap=5
         )
         docs.append(doc)
 
-    text_splitter = RecursiveCharacterTextSplitter(chunk_size=chunk_size, chunk_overlap=chunk_overlap)
+    text_splitter = RecursiveCharacterTextSplitter(
+        chunk_size=chunk_size,
+        chunk_overlap=chunk_overlap
+    )
     return text_splitter.split_documents(docs)
 
-# 데이터 로드 및 문서화
-dis_docs = load_csv_as_documents("docs/dis_prototype.csv", "질병")
-med_docs = load_csv_as_documents("docs/testmed.csv", "의약품")
-all_docs = dis_docs + med_docs
+def build_vectorstore():
+    # 데이터 로드 및 문서화
+    dis_docs = load_csv_as_documents("LLM_code/dis_prototype.csv", "질병")
+    med_docs = load_csv_as_documents("LLM_code/testmed.csv", "의약품")
+    all_docs = dis_docs + med_docs
 
-# 임베딩 및 벡터스토어 생성
-embedding_model_name = "madatnlp/km-bert"
-embeddings = HuggingFaceEmbeddings(model_name=embedding_model_name)
-vectorstore = FAISS.from_documents(all_docs, embeddings)
+    # 임베딩 및 벡터스토어 생성
+    embedding_model_name = "madatnlp/km-bert"
+    embeddings = HuggingFaceEmbeddings(model_name=embedding_model_name)
+    vectorstore = FAISS.from_documents(all_docs, embeddings)
 
-# 디렉터리 생성
-os.makedirs("faiss_store", exist_ok=True)
-vectorstore.save_local("faiss_store")
+    # 저장 경로: app/api/faiss_store
+    save_path = "app/api/faiss_store"
+    os.makedirs(save_path, exist_ok=True)
+    vectorstore.save_local(save_path)
+    print(f"✅ FAISS 벡터스토어가 '{save_path}' 경로에 저장되었습니다.")
+
+if __name__ == "__main__":
+    build_vectorstore()

--- a/app/api/amedi_llm_api.py
+++ b/app/api/amedi_llm_api.py
@@ -16,7 +16,7 @@ class QueryRequest(BaseModel):
 # 임베딩 모델 및 벡터스토어 로딩 (앱 실행 시 1회)
 embedding_model_name = "madatnlp/km-bert"
 embeddings = HuggingFaceEmbeddings(model_name=embedding_model_name)
-vectorstore = FAISS.load_local("faiss_store", embeddings, allow_dangerous_deserialization=True)
+vectorstore = FAISS.load_local("./app/api/faiss_store", embeddings, allow_dangerous_deserialization=True)
 
 # RAG 함수
 def rag_answer(question: str) -> str:

--- a/app/api/amedi_llm_api.py
+++ b/app/api/amedi_llm_api.py
@@ -1,0 +1,58 @@
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+from langchain_community.llms import Ollama
+from langchain_community.embeddings import HuggingFaceEmbeddings
+from langchain.vectorstores import FAISS
+from langchain.prompts import ChatPromptTemplate, SystemMessagePromptTemplate, HumanMessagePromptTemplate
+from langchain.chains import RetrievalQA
+
+# FastAPI 라우터
+router = APIRouter()
+
+# 사용자 입력 스키마
+class QueryRequest(BaseModel):
+    question: str
+
+# 임베딩 모델 및 벡터스토어 로딩 (앱 실행 시 1회)
+embedding_model_name = "madatnlp/km-bert"
+embeddings = HuggingFaceEmbeddings(model_name=embedding_model_name)
+vectorstore = FAISS.load_local("faiss_store", embeddings, allow_dangerous_deserialization=True)
+
+# RAG 함수
+def rag_answer(question: str) -> str:
+    retriever = vectorstore.as_retriever()
+    llm = Ollama(model="exaone3.5:7.8b", temperature=0.1, num_predict=1024)
+
+    system_template = (
+        "너는 전문 의료 정보 비서야.\n"
+        "사용자의 질문을 보고, 질병 / 의약품 중 어떤 카테고리에 해당하는지 판단하고,\n"
+        "관련 있는 문서만 참고해서 답변해. 문서의 출처(source_file)를 확인해서 불필요한 문서는 무시해야 해.\n"
+        "정보가 명확하지 않거나 문서에 없다면 '모르겠습니다'라고 답변해."
+    )
+    human_template = (
+        "질문: {question}\n\n"
+        "참고 가능한 문서 리스트 (내용과 출처 포함):\n\n{context}"
+    )
+    chat_prompt = ChatPromptTemplate.from_messages([
+        SystemMessagePromptTemplate.from_template(system_template),
+        HumanMessagePromptTemplate.from_template(human_template)
+    ])
+
+    qa = RetrievalQA.from_chain_type(
+        llm=llm,
+        retriever=retriever,
+        return_source_documents=True,
+        chain_type_kwargs={"prompt": chat_prompt}
+    )
+
+    result = qa.invoke({"query": question})
+    return result["result"]
+
+# POST /rag 엔드포인트
+@router.post("/llm/amedi")
+async def get_rag_response(query: QueryRequest):
+    try:
+        answer = rag_answer(query.question)
+        return {"question": query.question, "answer": answer}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))

--- a/app/main.py
+++ b/app/main.py
@@ -40,6 +40,10 @@ except ImportError as e:
     print(f"⚠️ LLM 질병 API 모듈을 찾을 수 없습니다: {e}")
     LLM_DISEASE_AVAILABLE = False
 
+# ========== 질병 + 의약품 통합 LLM API 라우터 import ==========
+from app.api import amedi_llm_api # 통합 LLM API (llm/amedi)
+
+
 # 환경변수 로드
 load_dotenv()
 
@@ -116,6 +120,12 @@ app.include_router(
     prefix="",  # /llm/hospital 그대로 사용
 )
 
+app.include_router(
+    amedi_llm_api.router, 
+    tags=["통합 LLM"],
+    prefix="",  
+)
+
 if LLM_DISEASE_AVAILABLE:
     app.include_router(
         disease_llm_router,
@@ -138,6 +148,7 @@ async def root():
         "의약품 추천 LLM": "/llm/medicine",
         "병원 추천": "/api/hospital",
         "병원 추천 LLM": "/llm/hospital",
+        "통합 예측 및 추천 LLM": "/llm/amedi",
         "API 문서": "/docs",
         "ReDoc 문서": "/redoc"
     }
@@ -161,6 +172,7 @@ async def root():
             "의약품 추천 llm": "/llm/medicine",
             "병원 추천": "/api/hospital",
             "병원 추천 llm": "/llm/hospital",
+            "통합 예측 및 추천 LLM": "/llm/amedi",
             "API 문서": "/docs",
             "ReDoc 문서": "/redoc"
         }


### PR DESCRIPTION
🛠 변경 파일

- LLM_code/amedi_embedding.py
- app/api/amedi_llm_api.py
- app/main.py

📌 작업 내용

- 질병 예측과 의약품 추천 기능을 통합하여 LLM 기반 fastAPI 코드 작성했습니다.
- 임베딩은 LLM_code 아래에다가 공유 드라이브에 있는 csv 파일을 다운받아서 넣은 뒤 실행 하셔야 합니다.
- main에서 엔드포인트 /llm/amedi로 넣어두었습니다.

✅ 확인 사항

- [ ] faiss 파일은 공유 드라이브에 faiss_store 폴더 그대로 app/api 안에다가 넣으시면 됩니다.

☑️ 추후 수정 사항

- [ ] 병원은 일단 원래 page를 활용하기로 했는데 가능하면 추후 챗봇에 추가하도록 하겠습니다.